### PR TITLE
fix: GenerationMixin._prepare_cache_for_generation() takes 6 positional arguments but 7 were given

### DIFF
--- a/vvembed/modular/modeling_vibevoice_inference.py
+++ b/vvembed/modular/modeling_vibevoice_inference.py
@@ -300,7 +300,7 @@ class VibeVoiceForConditionalGenerationInference(VibeVoicePreTrainedModel, Gener
         )
 
         max_cache_length = generation_config.max_length - 1
-        self._prepare_cache_for_generation(generation_config, model_kwargs, None, batch_size, max_cache_length, device)
+        self._prepare_cache_for_generation(generation_config, model_kwargs, batch_size, max_cache_length, device)
         model_kwargs['cache_position'] = torch.arange(input_ids_length, device=device, dtype=torch.long)
         for k, v in model_kwargs.items():
             if isinstance(v, torch.Tensor):


### PR DESCRIPTION
Here is complete log:

```
2025-09-04T21:43:48.746794 - [VibeVoice] VibeVoice generation failed: GenerationMixin._prepare_cache_for_generation() takes 6 positional arguments but 7 were given
2025-09-04T21:43:48.746818 - [VibeVoice] Single speaker speech generation failed: VibeVoice generation failed: GenerationMixin._prepare_cache_for_generation() takes 6 positional arguments but 7 were given
2025-09-04T21:43:48.747071 - !!! Exception during processing !!! Error generating speech: VibeVoice generation failed: GenerationMixin._prepare_cache_for_generation() takes 6 positional arguments but 7 were given
2025-09-04T21:43:48.747651 - Traceback (most recent call last):
  File "/Users/astgln/Documents/ComfyUI/custom_nodes/VibeVoice-ComfyUI/nodes/base_vibevoice.py", line 453, in _generate_with_vibevoice
    output = self.model.generate(
             ^^^^^^^^^^^^^^^^^^^^
  File "/Users/astgln/Documents/ComfyUI/.venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/astgln/Documents/ComfyUI/custom_nodes/VibeVoice-ComfyUI/vvembed/modular/modeling_vibevoice_inference.py", line 373, in generate
    generation_config, model_kwargs, input_ids, logits_processor, stopping_criteria = self._build_generate_config_model_kwargs(
                                                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/astgln/Documents/ComfyUI/custom_nodes/VibeVoice-ComfyUI/vvembed/modular/modeling_vibevoice_inference.py", line 303, in _build_generate_config_model_kwargs
    self._prepare_cache_for_generation(generation_config, model_kwargs, None, batch_size, max_cache_length, device)
TypeError: GenerationMixin._prepare_cache_for_generation() takes 6 positional arguments but 7 were given

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/astgln/Documents/ComfyUI/custom_nodes/VibeVoice-ComfyUI/nodes/single_speaker_node.py", line 110, in generate_speech
    audio_dict = self._generate_with_vibevoice(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/astgln/Documents/ComfyUI/custom_nodes/VibeVoice-ComfyUI/nodes/base_vibevoice.py", line 500, in _generate_with_vibevoice
    raise Exception(f"VibeVoice generation failed: {str(e)}")
Exception: VibeVoice generation failed: GenerationMixin._prepare_cache_for_generation() takes 6 positional arguments but 7 were given

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Applications/ComfyUI.app/Contents/Resources/ComfyUI/execution.py", line 496, in execute
    output_data, output_ui, has_subgraph, has_pending_tasks = await get_output_data(prompt_id, unique_id, obj, input_data_all, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb, hidden_inputs=hidden_inputs)
                                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Applications/ComfyUI.app/Contents/Resources/ComfyUI/execution.py", line 315, in get_output_data
    return_values = await _async_map_node_over_list(prompt_id, unique_id, obj, input_data_all, obj.FUNCTION, allow_interrupt=True, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb, hidden_inputs=hidden_inputs)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Applications/ComfyUI.app/Contents/Resources/ComfyUI/execution.py", line 289, in _async_map_node_over_list
    await process_inputs(input_dict, i)
  File "/Applications/ComfyUI.app/Contents/Resources/ComfyUI/execution.py", line 277, in process_inputs
    result = f(**inputs)
             ^^^^^^^^^^^
  File "/Users/astgln/Documents/ComfyUI/custom_nodes/VibeVoice-ComfyUI/nodes/single_speaker_node.py", line 131, in generate_speech
    raise Exception(f"Error generating speech: {str(e)}")
Exception: Error generating speech: VibeVoice generation failed: GenerationMixin._prepare_cache_for_generation() takes 6 positional arguments but 7 were given
```